### PR TITLE
add feature single-threaded to zksdk

### DIFF
--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -39,3 +39,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[features]
+single-threaded = []


### PR DESCRIPTION
#### Problem
As of current state, the spawning of threads makes it impossible to use the zk sdk in a wasm environment. At the same time, per default it only uses one thread (and is quite fast still) anyway. I would like to use the zk-sdk in a wasm project without having to fork it or (as I currently have) to copy a big part of the DiscreteLog functionality and replace the little part where it spawns a thread in a similar way as this PR does.

#### Summary of Changes
* adds a feature called `single-threaded`
* selectively (by default) does what it has done before, if single threaded is activated it will do the same but without spawning a thread for it.
* adds a test that can also be compiled with feature flag as e.g. 
`cargo test --package solana-zk-token-sdk --features "single-threaded"`

